### PR TITLE
Add action(link) color tokens

### DIFF
--- a/figma-tokens/$metadata.json
+++ b/figma-tokens/$metadata.json
@@ -11,7 +11,7 @@
     "semantic-tokens/typeScale",
     "semantic-tokens/lineHeight",
     "semantic-tokens/fontWeight",
-    "Working_Tokens/typeScale_Copy",
-    "Working_Tokens/lineHeight_Copy"
+    "prototype-tokens/lineHeight_Copy",
+    "prototype-tokens/action"
   ]
 }

--- a/figma-tokens/$themes.json
+++ b/figma-tokens/$themes.json
@@ -12,7 +12,9 @@
       "base-tokens/lineHeight": "enabled",
       "semantic-tokens/color": "enabled",
       "semantic-tokens/typography": "enabled",
-      "semantic-tokens/typeScale": "enabled"
+      "semantic-tokens/typeScale": "enabled",
+      "prototype-tokens/lineHeight_Copy": "disabled",
+      "prototype-tokens/action": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:18:11",
     "$figmaModeId": "18:1",

--- a/figma-tokens/prototype-tokens/action.json
+++ b/figma-tokens/prototype-tokens/action.json
@@ -1,0 +1,103 @@
+{
+  "action": {
+    "color": {
+      "text": {
+        "default": {
+          "idle": {
+            "value": "{color.calypso.dark}",
+            "type": "color",
+            "description": "Default action. Idle."
+          },
+          "hover": {
+            "value": "#007a8c",
+            "type": "color",
+            "description": "Default action. Hover."
+          },
+          "active": {
+            "value": "{color.calypso.medium}",
+            "type": "color",
+            "description": "Default action. Active."
+          }
+        },
+        "visited": {
+          "value": "#000",
+          "type": "color",
+          "description": "Default action. Visited."
+        },
+        "disabled": {
+          "value": "{color.text.disabled}",
+          "type": "color",
+          "description": "Default action. Disabled."
+        },
+        "danger": {
+          "idle": {
+            "value": "{color.candy apple.default}",
+            "type": "color",
+            "description": "Danger action. Idle."
+          },
+          "hover": {
+            "value": "{color.candy apple.dark}",
+            "type": "color",
+            "description": "Danger action. Hover."
+          },
+          "active": {
+            "value": "{color.candy apple.dark}",
+            "type": "color",
+            "description": "Danger action. Active."
+          }
+        },
+        "onSurface": {
+          "Idle": {
+            "value": "{color.Obsidian}",
+            "type": "color",
+            "description": "On Surface action. Idle."
+          },
+          "Hover": {
+            "value": "{action.color.text.onSurface.Idle}",
+            "type": "color",
+            "description": "On Surface action. Hover."
+          },
+          "active": {
+            "value": "{action.color.text.onSurface.Idle}",
+            "type": "color",
+            "description": "On Surface action. Active."
+          }
+        },
+        "inverse": {
+          "idle": {
+            "value": "{color.neutral.Olaf}",
+            "type": "color",
+            "description": "Inverse Action. Idle."
+          },
+          "hover": {
+            "value": "{color.calypso.medium}",
+            "type": "color",
+            "description": "Inverse Action. Hover."
+          },
+          "active": {
+            "value": "{color.neutral.Koala}",
+            "type": "color",
+            "description": "Inverse Action. Active."
+          }
+        }
+      },
+      "icon": {
+        "default": {
+          "value": "{color.neutral.Eerie}",
+          "type": "color",
+          "description": "Default action. Icon color"
+        },
+        "onSurface": {
+          "value": "{action.color.text.onSurface.Idle}",
+          "type": "color",
+          "description": "On Surface action. Icon color"
+        },
+        "inverse": {
+          "value": "{action.color.text.inverse.idle}",
+          "type": "color",
+          "description": "Inverse Action. Icon color."
+        }
+      }
+    }
+  }
+}

--- a/figma-tokens/prototype-tokens/lineHeight_Copy.json
+++ b/figma-tokens/prototype-tokens/lineHeight_Copy.json
@@ -1,0 +1,79 @@
+{
+  "lineHeight-full": {
+    "0": {
+      "value": "0px",
+      "type": "lineHeights",
+      "description": "Used in Breadcrumb arrows, Step Indicators"
+    },
+    "12": {
+      "value": "12px",
+      "type": "lineHeights",
+      "description": "?????????"
+    },
+    "14": {
+      "value": "14px",
+      "type": "lineHeights",
+      "description": "Used in Small Buttons"
+    },
+    "16": {
+      "value": "16px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "18": {
+      "value": "18px",
+      "type": "lineHeights",
+      "description": "Used for Microcopy"
+    },
+    "19": {
+      "value": "19px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "20": {
+      "value": "20px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "22": {
+      "value": "22px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "24": {
+      "value": "24px",
+      "type": "lineHeights",
+      "description": "Used for body copy. The default, universal line-height for text in the App."
+    },
+    "38": {
+      "value": "38px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "40": {
+      "value": "40px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "41": {
+      "value": "41px",
+      "type": "lineHeights",
+      "description": "Used to vertically center inside UIToggle"
+    },
+    "46": {
+      "value": "46px",
+      "type": "lineHeights",
+      "description": "Used in ?"
+    },
+    "normal": {
+      "value": "1.2",
+      "type": "lineHeights",
+      "description": "blah"
+    },
+    "inherit": {
+      "value": "inherit",
+      "type": "lineHeights",
+      "description": "Might not be a token?"
+    }
+  }
+}

--- a/figma-tokens/semantic-tokens/typography.json
+++ b/figma-tokens/semantic-tokens/typography.json
@@ -87,19 +87,9 @@
       "value": {
         "fontFamily": "{fontFamily.default}",
         "lineHeight": "{typeScale.display.heading6} * {lineHeight.display}",
-        "textCase": "{textTransform.uppercase}",
+        "textCase": "{textTransform.none}",
         "fontSize": "{typeScale.display.heading6}",
         "fontWeight": "{fontWeight.display.default}"
-      },
-      "type": "typography"
-    },
-    "heading7": {
-      "value": {
-        "fontFamily": "{fontFamily.default}",
-        "fontWeight": "{fontWeight.display.default}",
-        "fontSize": "{typeScale.display.heading6}",
-        "textCase": "{textTransform.none}",
-        "lineHeight": "{typeScale.display.heading6} * {lineHeight.display}"
       },
       "type": "typography"
     },


### PR DESCRIPTION
## What this does

* Renames `Working_Tokens` to `prototype-tokens`
* Removes `typescale-copy` tokens from `prototype-tokens`
* Adds `action` color tokens to `prototype-tokens`
* Removes `heading7` variants from `typography`
* Changes textTransform for `heading6` typography 