### PR TITLE
chore: sync color token changes from Figma

### DIFF
--- a/figma-tokens/Base/color.json
+++ b/figma-tokens/Base/color.json
@@ -2,22 +2,22 @@
   "color": {
     "lorax": {
       "default": {
-        "value": "#FF7A59",
+        "value": "#ff7a59",
         "type": "color",
         "description": "rgb(255, 122, 89)"
       },
       "dark": {
-        "value": "#E66E50",
+        "value": "#e66e50",
         "type": "color",
         "description": "rgb(230, 110, 80)"
       },
       "medium": {
-        "value": "#FFBCAC",
+        "value": "#ffbcac",
         "type": "color",
         "description": "rgb(255, 188, 172)"
       },
       "light": {
-        "value": "#FFF1EE",
+        "value": "#fff1ee",
         "type": "color",
         "description": "rgb(255, 241, 238)"
       }
@@ -42,132 +42,132 @@
     },
     "candy apple": {
       "default": {
-        "value": "#F2545B",
+        "value": "#f2545b",
         "type": "color",
         "description": "rgb(242, 84, 91)"
       },
       "dark": {
-        "value": "#D94C53",
+        "value": "#d94c53",
         "type": "color",
         "description": "rgb(217, 76, 83)"
       },
       "medium": {
-        "value": "#F8A9AD",
+        "value": "#f8a9ad",
         "type": "color",
         "description": "rgb(248, 169, 173)"
       },
       "light": {
-        "value": "#FDEDEE",
+        "value": "#fdedee",
         "type": "color",
         "description": "rgb(253, 237, 238)"
       }
     },
     "marigold": {
       "default": {
-        "value": "#F5C26B",
+        "value": "#f5c26b",
         "type": "color",
         "description": "rgb(245, 194, 107)"
       },
       "dark": {
-        "value": "#DBAE60",
+        "value": "#dbae60",
         "type": "color",
         "description": "rgb(219, 174, 96)"
       },
       "medium": {
-        "value": "#FAE0B5",
+        "value": "#fae0b5",
         "type": "color",
         "description": "rgb(250, 224, 181)"
       },
       "light": {
-        "value": "#FEF8F0",
+        "value": "#fef8f0",
         "type": "color",
         "description": "rgb(254, 248, 240)"
       }
     },
     "oz": {
       "default": {
-        "value": "#00BDA5",
+        "value": "#00bda5",
         "type": "color",
         "description": "rgb(0, 189, 165)"
       },
       "dark": {
-        "value": "#00A38D",
+        "value": "#00a38d",
         "type": "color",
         "description": "rgb(0, 163, 141)"
       },
       "medium": {
-        "value": "#7FDED2",
+        "value": "#7fded2",
         "type": "color",
         "description": "rgb(127, 222, 210)"
       },
       "light": {
-        "value": "#E5F8F6",
+        "value": "#e5f8f6",
         "type": "color",
         "description": "rgb(229, 248, 246)"
       }
     },
     "norman": {
       "default": {
-        "value": "#F2547D",
+        "value": "#f2547d",
         "type": "color",
         "description": "rgb(242, 84, 125)"
       },
       "dark": {
-        "value": "#D94C71",
+        "value": "#d94c71",
         "type": "color",
         "description": "rgb(217, 76, 113)"
       },
       "medium": {
-        "value": "#F9AABE",
+        "value": "#f9aabe",
         "type": "color",
         "description": "rgb(249, 170, 190)"
       },
       "light": {
-        "value": "#FDEDF2",
+        "value": "#fdedf2",
         "type": "color",
         "description": "rgb(253, 237, 242)"
       }
     },
     "sorbet": {
       "default": {
-        "value": "#FF8F59",
+        "value": "#ff8f59",
         "type": "color",
         "description": "rgb(255, 143, 89)"
       },
       "dark": {
-        "value": "#E68250",
+        "value": "#e68250",
         "type": "color",
         "description": "rgb(230, 130, 80)"
       },
       "medium": {
-        "value": "#FFC7AC",
+        "value": "#ffc7ac",
         "type": "color",
         "description": "rgb(255, 199, 172)"
       },
       "light": {
-        "value": "#FFF3EE",
+        "value": "#fff3ee",
         "type": "color",
         "description": "rgb(255, 243, 238)"
       }
     },
     "thunderdome": {
       "default": {
-        "value": "#6A78D1",
+        "value": "#6a78d1",
         "type": "color",
         "description": "rgb(106, 120, 209)"
       },
       "dark": {
-        "value": "#5E6AB8",
+        "value": "#5e6ab8",
         "type": "color",
         "description": "rgb(94, 106, 184)"
       },
       "medium": {
-        "value": "#B4BBE8",
+        "value": "#b4bbe8",
         "type": "color",
         "description": "rgb(180, 187, 232)"
       },
       "light": {
-        "value": "#F0F1FA",
+        "value": "#f0f1fa",
         "type": "color",
         "description": "rgb(240, 241, 250)"
       }
@@ -179,47 +179,47 @@
         "description": "rgb(37, 51, 66)"
       },
       "pantera": {
-        "value": "#2D3E50",
+        "value": "#2d3e50",
         "type": "color",
         "description": "rgb(45, 62, 80)"
       },
       "heffalump": {
-        "value": "#425B76",
+        "value": "#425b76",
         "type": "color",
         "description": "rgb(66, 91, 118)"
       },
       "slinky": {
-        "value": "#516F90",
+        "value": "#516f90",
         "type": "color",
         "description": "rgb(81, 111, 144)"
       },
       "eerie": {
-        "value": "#7C98B6",
+        "value": "#7c98b6",
         "type": "color",
         "description": "rgb(124, 152, 182)"
       },
       "flint": {
-        "value": "#99ACC2",
+        "value": "#99acc2",
         "type": "color",
         "description": "rgb(153, 172, 194)"
       },
       "battleship": {
-        "value": "#CBD6E2",
+        "value": "#cbd6e2",
         "type": "color",
         "description": "rgb(203, 214, 226)"
       },
       "great white": {
-        "value": "#DFE3EB",
+        "value": "#dfe3eb",
         "type": "color",
         "description": "rgb(223, 227, 235)"
       },
       "koala": {
-        "value": "#EAF0F6",
+        "value": "#eaf0f6",
         "type": "color",
         "description": "rgb(234, 240, 246)"
       },
       "gypsum": {
-        "value": "#F5F8FA",
+        "value": "#f5f8fa",
         "type": "color",
         "description": "rgb(245, 248, 250)"
       },
@@ -235,7 +235,7 @@
       }
     },
     "obsidian": {
-      "value": "#33475b",
+      "value": "#e13333",
       "type": "color",
       "description": "rgb(51, 71, 91)"
     }

--- a/figma-tokens/Semantic/color.json
+++ b/figma-tokens/Semantic/color.json
@@ -7,7 +7,7 @@
         "description": "The default color of text in the product."
       },
       "subtle": {
-        "value": "{color.neutral.slinky}",
+        "value": "{color.neutral.flat earth}",
         "type": "color",
         "description": "The color of microcopy in the product"
       },
@@ -29,12 +29,12 @@
       "danger": {
         "value": "{color.candy apple.default}",
         "type": "color",
-        "description": "The color of micorcopy that indicates an error or danger message"
+        "description": "The color of microcopy that indicates an error or danger message"
       },
       "success": {
-        "value": "{color.oz.default}",
+        "value": "{color.oz.dark}",
         "type": "color",
-        "description": "The color of micorcopy that indicates success or positive messaging"
+        "description": "The color of microcopy that indicates success or positive messaging"
       }
     },
     "surface": {
@@ -47,7 +47,7 @@
         "type": "color"
       },
       "transparent": {
-        "value": "rgba(0, 0, 0, 0)",
+        "value": "#00000000",
         "type": "color"
       }
     }


### PR DESCRIPTION
## Summary

Color variable changes made in Figma, synced back to the token JSON files.

### Base/color.json
- `obsidian`: `#33475b` → `#e13333`

### Semantic/color.json
- `text/subtle`: `{color.neutral.slinky}` → `{color.neutral.flat earth}`
- `text/success`: `{color.oz.default}` → `{color.oz.dark}`