### PR TITLE
Add Dark mode Semantic color tokens

### DIFF
--- a/figma-tokens/Semantic/color-dark.json
+++ b/figma-tokens/Semantic/color-dark.json
@@ -1,0 +1,65 @@
+{
+  "color": {
+    "text": {
+      "default": {
+        "$value": "{color.neutral.gypsum}",
+        "$type": "color",
+        "$description": "The default color of text in the product.",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:49" } }
+      },
+      "subtle": {
+        "$value": "{color.neutral.koala}",
+        "$type": "color",
+        "$description": "The color of microcopy in the product",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:50" } }
+      },
+      "nonessential": {
+        "$value": "{color.neutral.battleship}",
+        "$type": "color",
+        "$description": "The color of placeholder text inside an input",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:51" } }
+      },
+      "disabled": {
+        "$value": "{color.neutral.flint}",
+        "$type": "color",
+        "$description": "The color text within a disabled interactive element",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:52" } }
+      },
+      "inverse": {
+        "$value": "{color.neutral.monolith}",
+        "$type": "color",
+        "$description": "The color of text when placed on a dark background",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:53" } }
+      },
+      "danger": {
+        "$value": "{color.candy apple.medium}",
+        "$type": "color",
+        "$description": "The color of microcopy that indicates an error or danger message",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:54" } }
+      },
+      "success": {
+        "$value": "{color.oz.medium}",
+        "$type": "color",
+        "$description": "The color of microcopy that indicates success or positive messaging",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:55" } }
+      }
+    },
+    "surface": {
+      "default": {
+        "$value": "{color.neutral.flat earth}",
+        "$type": "color",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:56" } }
+      },
+      "elevation1": {
+        "$value": "{color.neutral.heffalump}",
+        "$type": "color",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:57" } }
+      },
+      "transparent": {
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0], "alpha": 0, "hex": "#000000" },
+        "$type": "color",
+        "$extensions": { "com.figma": { "variableId": "VariableID:15:58" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `figma-tokens/Semantic/color-dark.json` with Dark mode values for all 10 Semantic color tokens, sourced directly from Figma (`VariableCollectionId:15:48`, `modeId:22:0`). DTCG 2025.10 compliant: `$value`/`$type`/`$description`, alias references preserved, Figma IDs in `$extensions.com.figma.variableId`.

## Dark mode token mapping

| Token | Dark value |
|---|---|
| text/default | `{color.neutral.gypsum}` |
| text/subtle | `{color.neutral.koala}` |
| text/nonessential | `{color.neutral.battleship}` |
| text/disabled | `{color.neutral.flint}` |
| text/inverse | `{color.neutral.monolith}` |
| text/danger | `{color.candy apple.medium}` |
| text/success | `{color.oz.medium}` |
| surface/default | `{color.neutral.flat earth}` |
| surface/elevation1 | `{color.neutral.heffalump}` |
| surface/transparent | `#00000000` |

## Test plan
- [ ] Verify all 10 token values match the Figma Semantic Dark mode
- [ ] Confirm alias references resolve correctly against `Base/color.json`
- [ ] Validate file against DTCG 2025.10 format spec

 Generated with [Claude Code](https://claude.com/claude-code)